### PR TITLE
why auth stack would require a account stack check

### DIFF
--- a/mod_authnz_pam.c
+++ b/mod_authnz_pam.c
@@ -176,7 +176,6 @@ void store_password_to_cache(request_rec * r, const char * login, const char * p
 #define _EXTERNAL_AUTH_ERROR_ENV_NAME "EXTERNAL_AUTH_ERROR"
 #define _PAM_STEP_AUTH 1
 #define _PAM_STEP_ACCOUNT 2
-#define _PAM_STEP_ALL 3
 static authn_status pam_authenticate_with_login_password(request_rec * r, const char * pam_service,
 	const char * login, const char * password, int steps) {
 	pam_handle_t * pamh = NULL;
@@ -246,7 +245,7 @@ static authn_status pam_auth_account(request_rec * r, const char * login, const 
 		return AUTH_GENERAL_ERROR;
 	}
 
-	return pam_authenticate_with_login_password(r, conf->pam_service, login, password, _PAM_STEP_ALL);
+	return pam_authenticate_with_login_password(r, conf->pam_service, login, password, _PAM_STEP_AUTH);
 }
 
 static const authn_provider authn_pam_provider = {


### PR DESCRIPTION
i learned this by write using it with my own ldap module
so the code will try to do an account stack operation even you only ask it to do auth

say:
you have pam-service file as

```bash
auth    required   pam_ldap_go.so
```

you do not want it to do an account stack operation
but it will do a full _PAM_STEP_ALL as default for auth stack


in another case you have

```bash
auth    required   pam_ldap_go.so
account required   pam_ldap_go.so
```

in auth stack, it will do full _PAM_STEP_ALL including a pam_acct_mgmt call
then it will do a _PAM_STEP_ACCOUNT, which is already done in first auth call
