### PR TITLE
Store password to cache after passing all pam check

### DIFF
--- a/mod_authnz_pam.c
+++ b/mod_authnz_pam.c
@@ -197,11 +197,6 @@ static authn_status pam_authenticate_with_login_password(request_rec * r, const 
 			param = login;
 			stage = "PAM authentication failed for user";
 			ret = pam_authenticate(pamh, PAM_SILENT | PAM_DISALLOW_NULL_AUTHTOK);
-#if AP_MODULE_MAGIC_AT_LEAST(20100625,0)
-			if (ret == PAM_SUCCESS) {
-				store_password_to_cache(r, login, password);
-			}
-#endif
 		}
 		if ((ret == PAM_SUCCESS) && (steps & _PAM_STEP_ACCOUNT)) {
 			param = login;
@@ -232,6 +227,9 @@ static authn_status pam_authenticate_with_login_password(request_rec * r, const 
 	r->user = apr_pstrdup(r->pool, login);
 	ap_log_rerror(APLOG_MARK, APLOG_INFO, 0, r, SHOW_MODULE "PAM authentication passed for user %s", login);
 	pam_end(pamh, ret);
+#if AP_MODULE_MAGIC_AT_LEAST(20100625,0)
+    store_password_to_cache(r, login, password);
+#endif
 	return AUTH_GRANTED;
 }
 

--- a/tests/config.sh
+++ b/tests/config.sh
@@ -5,6 +5,7 @@ set -x
 
 sed -i 's/^MaxClients.*/MaxClients 1/' /etc/httpd/conf/httpd.conf
 mkdir -p /etc/pam-auth
+mkdir -p /etc/pam-account
 cp -p tests/auth.cgi /var/www/cgi-bin/auth.cgi
 cp -p tests/pam-exec /usr/bin/pam-exec
 cp tests/pam-web /etc/pam.d/web

--- a/tests/pam-exec
+++ b/tests/pam-exec
@@ -2,18 +2,12 @@
 
 echo "$0: $PAM_TYPE $PAM_USER"
 
-if [ "$PAM_TYPE" == 'auth' ] || [ "$PAM_TYPE" == 'account' ] ; then
+if [ "$PAM_TYPE" == 'auth' ] ; then
 	PAM_FILE="/etc/pam-auth/$PAM_USER"
 	if ! [ -f $PAM_FILE ] ; then
 		echo "No [$PAM_FILE] for user [$PAM_USER]" >&2
 		exit 2
 	fi
-	if [ $PAM_TYPE == 'account' ] ; then
-		# For account check, existing file is enough to allow access
-		echo "$0: account [$PAM_USER] ok"
-		exit 0
-	fi
-
 	# For auth, we compare the passwords
 	read PASSWORD
 	read CHECK_PASSWORD < $PAM_FILE
@@ -24,5 +18,17 @@ if [ "$PAM_TYPE" == 'auth' ] || [ "$PAM_TYPE" == 'account' ] ; then
 	echo "Provided password [$PASSWORD] does not match expected [$CHECK_PASSWORD]" >&2
 	exit 3
 fi
+
+if [ "$PAM_TYPE" == 'account' ] ; then
+	PAM_FILE="/etc/pam-account/$PAM_USER"
+	if ! [ -f $PAM_FILE ] ; then
+		echo "No [$PAM_FILE] for user [$PAM_USER]" >&2
+		exit 2
+	fi
+	# For account check, existing file is enough to allow access
+	echo "$0: account [$PAM_USER] ok"
+	exit 0
+fi
+
 echo "Unsupported PAM_TYPE [$PAM_TYPE]" >&2
 exit 4

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -16,14 +16,15 @@ rm -f /etc/pam-auth/*
 echo "Testing Require pam-account"
 curl -s -D /dev/stdout -o /dev/null http://localhost/authz | tee /dev/stderr | grep 401
 curl -u alice:Tajnost -s -D /dev/stdout -o /dev/null http://localhost/authz | tee /dev/stderr | grep 401
-touch /etc/pam-auth/alice
+touch /etc/pam-account/alice
 curl -u alice:Tajnost -s http://localhost/authz | tee /dev/stderr | grep 'User alice'
 
 echo "Testing AuthBasicProvider PAM"
 curl -s -D /dev/stdout -o /dev/null http://localhost/authn | tee /dev/stderr | grep 401
 curl -u bob:Secret -s -D /dev/stdout -o /dev/null http://localhost/authn | tee /dev/stderr | grep 401
-touch /etc/pam-auth/bob
+touch /etc/pam-account/bob
 curl -u bob:Secret -s -D /dev/stdout -o /dev/null http://localhost/authn | tee /dev/stderr | grep 401
+touch /etc/pam-auth/bob
 echo Secret > /etc/pam-auth/bob
 curl -u bob:Secret -s http://localhost/authn | tee /dev/stderr | grep 'User bob'
 echo Secret2 > /etc/pam-auth/bob

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -41,6 +41,15 @@ if rpm -ql httpd | grep mod_authn_socache ; then
 	curl -u bob:Secret -s http://localhost/authn-cached | tee /dev/stderr | grep 'User bob'
 	sleep 11
 	curl -u bob:Secret -s -D /dev/stdout -o /dev/null http://localhost/authn-cached | tee /dev/stderr | grep 401
+
+	###### make sure we won't store the credential to cache if the credential didn't pass pam account check
+	sleep 11
+	rm /etc/pam-account/bob
+	curl -u bob:Secret2 -s -D /dev/stdout -o /dev/null http://localhost/authn-cached | tee /dev/stderr | grep 401
+	curl -u bob:Secret2 -s -D /dev/stdout -o /dev/null http://localhost/authn-cached | tee /dev/stderr | grep 401
+	touch /etc/pam-account/bob
+	curl -u bob:Secret2 -s http://localhost/authn-cached | tee /dev/stderr | grep 'User bob'
+	######
 fi
 
 echo OK $0.


### PR DESCRIPTION
The credential will be cached even if it didn't pass all pam checks, the user might be able to login if he try it twice