### PR TITLE
Use ap_get_useragent_host instead of ap_get_remote_host

### DIFF
--- a/mod_authnz_pam.c
+++ b/mod_authnz_pam.c
@@ -186,7 +186,11 @@ static authn_status pam_authenticate_with_login_password(request_rec * r, const 
 	int ret;
 	ret = pam_start(pam_service, login, &pam_conversation, &pamh);
 	if (ret == PAM_SUCCESS) {
+#if AP_MODULE_MAGIC_AT_LEAST(20120211,56)
+		const char * remote_host_or_ip = ap_get_useragent_host(r, REMOTE_NAME, NULL);
+#else
 		const char * remote_host_or_ip = ap_get_remote_host(r->connection, r->per_dir_config, REMOTE_NAME, NULL);
+#endif
 		if (remote_host_or_ip) {
 			stage = "PAM pam_set_item PAM_RHOST failed for service";
 			ret = pam_set_item(pamh, PAM_RHOST, remote_host_or_ip);


### PR DESCRIPTION
    - according to https://www.apachelounge.com/Changelog-2.4.html,
      modules should be updated to inquire for ap_get_useragent_host()
      in place of ap_get_remote_host().

    - use module magic number 20120211,56 to determine whether to use ap_get_useragent_host
    (according to https://github.com/apache/httpd/blob/2.4.x/include/ap_mmn.h)